### PR TITLE
Added docs for ChRIS and covidnet on WSL

### DIFF
--- a/workflows/ChRIS_on_WSL.asciidoc
+++ b/workflows/ChRIS_on_WSL.asciidoc
@@ -1,0 +1,46 @@
+Instantiating a Local ChRIS instance on WSL
+-------------------------------------------
+
+This is a step-by-step guide on instantiating a local ChRIS instance on a Windows Host using WSL 2 (Windows Subsystem for Linux 2)
+
+Enabling and/or installing WSL and a Linux distribution
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+* Follow the *Manual Installation Steps* from the https://docs.microsoft.com/en-us/windows/wsl/install-win10#manual-installation-steps[Windows Subsystem for Linux Installation Guide for Windows 10^]  
+
+* At the end of Step 6 in the link above, you should have your choice of Linux distribution installed and configured with WSL.
+
+
+
+Installing docker and docker-compose (on the terminal) on Ubuntu on WSL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Here's the list of commands in the specified order to be run on the terminal - 
+
+. Installing `docker`
+
+    * Follow the *Install using the repository* steps from the https://docs.docker.com/engine/install/ubuntu/[Install Docker Engine on Ubuntu guide^]
+    
+    * Docker Engine is installed and running. The `docker` group is created but no users are added to it. You need to use `sudo` to run Docker commands. Continue to https://docs.docker.com/engine/install/linux-postinstall/[Linux postinstall^] to allow non-privileged users to run Docker commands and for other optional configuration steps.
+
+. Installing `docker-compose`
+
+    * Follow the *Install Compose on Linux systems* steps from the https://docs.docker.com/compose/install/#install-compose-on-linux-systems[Install Docker Compose Guide^]
+
+
+Instantiating a local ChRIS instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Once you have `docker` and `docker-compose installed`, open a new terminal window and run `sudo dockerd`
+    - `dockerd` is the daemon service for docker containers
+
+* Instantiating CUBE
+    - Once you have `dockerd` running, open a new terminal window and follow the steps in the https://github.com/FNNDSC/ChRIS_ultron_backEnd/blob/master/README.md[ChRIS Ultron Backend ReadME^] to instatiate an instance of the ChRIS backend services
+
+    - Once the system is "up", you can add more compute plugins to the ecosystem by running:
+    `./postscript.sh`
+
+* Instatiating the ChRIS UI 
+    - Once you have CUBE running, open a new terminal window and follow the steps in the https://github.com/FNNDSC/ChRIS_ui[ChRIS UI ReadME^]
+

--- a/workflows/Covidnet_on_WSL.asciidoc
+++ b/workflows/Covidnet_on_WSL.asciidoc
@@ -1,0 +1,76 @@
+Running the covidnet workflow on a local ChRIS instance using WSL
+-----------------------------------------------------------------
+
+. Instantiate a local ChRIS instance on WSL by following the steps in the ChRIS_on_WSL guide
+
+. `cd` to the home directory and clone the `CHRIS_docs` repo
++
+[source,shell]
+-----------------               
+    git clone https://github.com/FNNDSC/CHRIS_docs.git
+-----------------
+
+. For the next step, you can either - 
+    - cd to the workflows directory in CHRIS_docs
++
+[source,shell]
+-----------------               
+    cd CHRIS_docs/workflows
+-----------------
+    
+
+    - Copy `covidplugins_upload.sh` and paste it into your `ChRIS_ultron_backEnd` directory
++
+*OR*
+
+    - `cd` to `ChRIS_ultron_backEnd`
+
+    - create a new bash file titled -  `covidplugins_upload.sh` and paste the following lines of code in that file:
++
+[source,shell]
+-----------------
+        ./plugin_add.sh  "\
+		        	            fnndsc/pl-lungct,		\
+			                    fnndsc/pl-med2img,		\
+			                    fnndsc/pl-covidnet,		\
+        	            		fnndsc/pl-pdfgeneration
+        "  
+-----------------
+
+. Now, doing either of the things in step 3, you should be in the `ChRIS_ultron_backEnd`  directory and have `covidplugins_upload.sh` in it
+
+. Run that script while you have a running ChRIS instance to add your plugins for the covidnet workflow
++
+[source,shell]
+-----------------               
+    ./covidplugins_upload.sh
+-----------------
+
+. Run the following command to grep the ip of your localhost
++
+[source,shell]
+-----------------               
+    ip route | grep -v docker
+-----------------
+
+    - This command should print something that resembles this on your terminal:
++
+[source,shell]
+-----------------               
+    default via 172.24.112.1 dev eth0
+    172.24.112.0/20 dev eth0 proto kernel scope link src 172.24.126.43
+-----------------    
+
+. Replace <ip> with the ip address printed after src in the following command and run it:
++
+[source,shell]
+-----------------               
+    export HOST_IP=<ip> 
+-----------------
+
+. Run the following command to run the covidnet workflow on your local ChRIS instance:
++
+[source,shell]
+-----------------               
+    ./covidnet.sh -a $HOST_IP  
+-----------------

--- a/workflows/Covidnet_on_WSL.asciidoc
+++ b/workflows/Covidnet_on_WSL.asciidoc
@@ -57,8 +57,8 @@ Running the covidnet workflow on a local ChRIS instance using WSL
 +
 [source,shell]
 -----------------               
-    default via 172.24.112.1 dev eth0
-    172.24.112.0/20 dev eth0 proto kernel scope link src 172.24.126.43
+    default via 111.22.333.1 dev eth0
+    111.22.333.0/20 dev eth0 proto kernel scope link src 111.22.126.43
 -----------------    
 
 . Replace <ip> with the ip address printed after src in the following command and run it:


### PR DESCRIPTION
These docs are essentially a step by step guide to - 

a) Instantiate a local ChRIS instance on WSL
b) Run the covidnet workflow on that instance