### PR TITLE
Modify covidnet.sh to parse analysis dates differently

### DIFF
--- a/workflows/covidnet.sh
+++ b/workflows/covidnet.sh
@@ -491,7 +491,7 @@ if (( b_imageList )) ; then
 fi
 
 if (( b_useAnalysisDates )) ; then
-    read -a a_analysisDate <<< $(echo "$ANALYSISDATES" | tr ',' ' ')
+    IFS=',' read -ra a_analysisDate <<< $(echo "$ANALYSISDATES")
 fi
 
 if (( b_imageList && ! b_skipFScheck )) ; then
@@ -607,7 +607,7 @@ title -d 1 "Building and Scheduling workflow..."
             if (( b_useAnalysisDates )) ; then
                 CREATIONDATE=${a_analysisDate[$idx]}
             fi
-            TIMESTAMP=$(date -d $CREATIONDATE +"%s%3N")
+            TIMESTAMP=$(date -d "$CREATIONDATE" +"%s%3N")
             JSONcontents=$(
                 jq --arg key0 'timestamp' --arg value0 $TIMESTAMP           \
                    --arg key1 'img'       --arg value1 "$JSONquery"         \


### PR DESCRIPTION
Using the command 
```./covidnet.sh -a localhost -p 8000 -F -K -i DAI000036.dcm,DAI000068.dcm -D "2019-09-30 08:23:30,2019-07-30 22:20:10"```
Before
![image](https://user-images.githubusercontent.com/53355975/124659809-5a265900-de73-11eb-81da-6fe43960a0ca.png)
![image](https://user-images.githubusercontent.com/53355975/124659875-6f9b8300-de73-11eb-852c-a2d72fda3dfe.png)

![image](https://user-images.githubusercontent.com/53355975/124659963-90fc6f00-de73-11eb-94b9-9b8fa83e90a7.png)
![image](https://user-images.githubusercontent.com/53355975/124659992-9c4f9a80-de73-11eb-9a35-b7b3c21266d6.png)

We see here that the date and time are being parsed as two different values and applied so that the first file only gets a date and defaults the time to midnight while the seocnd file only gets a time, so defaults its date to today (July 6).

After
![image](https://user-images.githubusercontent.com/53355975/124660118-c43efe00-de73-11eb-9bec-8ff7ce178d7c.png)
![image](https://user-images.githubusercontent.com/53355975/124660144-cdc86600-de73-11eb-98ad-842331951cee.png)

![image](https://user-images.githubusercontent.com/53355975/124660168-d6b93780-de73-11eb-922b-3b8e1ba0a8a7.png)
![image](https://user-images.githubusercontent.com/53355975/124660195-e33d9000-de73-11eb-86be-7071f31fe06a.png)

Here, both of the files have the correct timestamp.
